### PR TITLE
Remove explicit composer installer version in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,9 +5,6 @@
 	"keywords": ["cakephp", "eager", "load", "contain", "containable"],
 	"homepage": "https://github.com/civica-io/cakephp-eager-loader",
 	"license": "MIT",
-	"require": {
-		"composer/installers": "^1.0.23"
-	},
 	"extra": {
 		"installer-name": "EagerLoader"
 	}


### PR DESCRIPTION
On the elstats repo, this specifying the composer version is falsely being detected by Dependabot as composer itself as falsely being out of date (and incompatible w Dependabot) when it is not.